### PR TITLE
extract node source rpm into a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,5 +17,5 @@ nodejs_default_in_apt: "0.12"
 nodejs_default_in_yum: "0.10"
 
 nodejs4_nodesource_rpm: https://rpm.nodesource.com/pub_4.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
-nodejs5_nodesource_rpm: https://rpm.nodesource.com/pub_4.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
-nodejs6_nodesource_rpm: https://rpm.nodesource.com/pub_4.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
+nodejs5_nodesource_rpm: https://rpm.nodesource.com/pub_5.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
+nodejs6_nodesource_rpm: https://rpm.nodesource.com/pub_6.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,5 @@ nodejs_default_in_apt: "0.12"
 nodejs_default_in_yum: "0.10"
 
 nodejs4_nodesource_rpm: https://rpm.nodesource.com/pub_4.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
+nodejs5_nodesource_rpm: https://rpm.nodesource.com/pub_4.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm
+nodejs6_nodesource_rpm: https://rpm.nodesource.com/pub_4.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,5 @@ nodejs_compile: True   # install tools for compiling native addons from npm
 
 nodejs_default_in_apt: "0.12"
 nodejs_default_in_yum: "0.10"
+
+nodejs4_nodesource_rpm: https://rpm.nodesource.com/pub_4.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm

--- a/tasks/use-yum.yml
+++ b/tasks/use-yum.yml
@@ -29,7 +29,7 @@
       when: (nodejs_version|string) | match('^5.*$')
 
     - name: add NodeSource repository for Node.js 4.0
-      yum: name=https://rpm.nodesource.com/pub_4.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm state=present
+      yum: name={{nodejs4_nodesource_rpm}} state=present
       when: (nodejs_version|string) | match('^4.*$')
 
     - name: add NodeSource repository for Node.js 0.xx

--- a/tasks/use-yum.yml
+++ b/tasks/use-yum.yml
@@ -21,15 +21,15 @@
 - block:
 
     - name: add NodeSource repository for Node.js 6.0
-      yum: name=https://rpm.nodesource.com/pub_6.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm state=present
+      yum: name= {{ nodejs6_nodesource_rpm }} state=present
       when: (nodejs_version|string) | match('^6.*$')
 
     - name: add NodeSource repository for Node.js 5.0
-      yum: name=https://rpm.nodesource.com/pub_5.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm state=present
+      yum: name={{ nodejs5_nodesource_rpm }} state=present
       when: (nodejs_version|string) | match('^5.*$')
 
     - name: add NodeSource repository for Node.js 4.0
-      yum: name={{nodejs4_nodesource_rpm}} state=present
+      yum: name={{ nodejs4_nodesource_rpm }} state=present
       when: (nodejs_version|string) | match('^4.*$')
 
     - name: add NodeSource repository for Node.js 0.xx


### PR DESCRIPTION
Extracting nodesource rpm  to a variable in defaults/main.yml , in order to allow  nodejs installation without internet access.
In that way , the variables can be defined in vars/main.yml to match the user needs.