### PR TITLE
replacing pkg python-software-properties in favor of newer pkg softwa…

### DIFF
--- a/tasks/use-apt.yml
+++ b/tasks/use-apt.yml
@@ -9,7 +9,7 @@
 - name: install add-apt-repository and https binaries for Ansible to work
   apt: name={{ item }} state=present update_cache=yes
   with_items:
-    - python-software-properties
+    - software-properties-common
     - apt-transport-https
 
 - name: install tools for compiling native addons from npm


### PR DESCRIPTION
**Why?**
[Fixes ansible install error](https://travis-ci.org/Eimert/ansible-role-awx/jobs/372609618) (pkg not found) on Debian stretch (current stable release).<br>

Error reproduced in debian stretch docker container:
```
root@704e4f380c4a:/# apt-get install -y python-software-properties
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package python-software-properties is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  software-properties-common

E: Package 'python-software-properties' has no installation candidate

```

Note: I haven't done any regressions tests on other distro's.