### PR TITLE
Fixes nodejs version not found.

### DIFF
--- a/test.yml
+++ b/test.yml
@@ -6,7 +6,7 @@
     - 'defaults/main.yml'
 
   vars:
-    nodejs_version: "6.0.0"
+    nodejs_version: "6.x"
     #nodejs_version: "5"
     #nodejs_version: "5.7.0"
     #nodejs_version: 5.7.0


### PR DESCRIPTION
install 'nodejs=6.0.0*'' failed: E: Version '6.0.0*' for 'nodejs' was not found\n"